### PR TITLE
Fix LinkedIn certification URL handling to allow optional empty string

### DIFF
--- a/libs/parser/src/linkedin/index.ts
+++ b/libs/parser/src/linkedin/index.ts
@@ -153,7 +153,7 @@ export class LinkedInParser implements Parser<JSZip, LinkedIn> {
           id: createId(),
           name: certification.Name,
           issuer: certification.Authority,
-          url: { ...defaultCertification.url, href: certification.Url || "" },
+          url: { ...defaultCertification.url, href: certification.Url ?? "" },
           date: `${certification["Started On"]} - ${certification["Finished On"] ?? "Present"}`,
         });
       }

--- a/libs/parser/src/linkedin/index.ts
+++ b/libs/parser/src/linkedin/index.ts
@@ -153,7 +153,7 @@ export class LinkedInParser implements Parser<JSZip, LinkedIn> {
           id: createId(),
           name: certification.Name,
           issuer: certification.Authority,
-          url: { ...defaultCertification.url, href: certification.Url },
+          url: { ...defaultCertification.url, href: certification.Url || "" },
           date: `${certification["Started On"]} - ${certification["Finished On"] ?? "Present"}`,
         });
       }

--- a/libs/parser/src/linkedin/schema/certification.ts
+++ b/libs/parser/src/linkedin/schema/certification.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const certificationSchema = z.object({
   Name: z.string(),
-  Url: z.string().url(),
+  Url: z.string().url().optional().or(z.literal("")),
   Authority: z.string(),
   "Started On": z.string(),
   "Finished On": z.string().optional(),


### PR DESCRIPTION
## Problem
LinkedIn data exports often contain certifications with empty URL fields, which were causing validation errors during import:

```json
{
    "validation": "url",
    "code": "invalid_string",
    "message": "Invalid url",
    "path": ["Certifications", 0, "Url"]
}
```

## Solution
- Modified `libs/parser/src/linkedin/schema/certification.ts` to allow empty URLs and optional URL fields
- Updated `libs/parser/src/linkedin/index.ts` to handle empty URLs gracefully
- Maintains backward compatibility with valid URLs

## Changes
- **certification.ts**: Changed `Url: z.string().url()` to `Url: z.string().url().optional().or(z.literal(""))`
- **index.ts**: Updated certification processing to use `certification.Url || ""` for empty URL handling

## Testing
- ✅ Certifications with valid URLs continue to work
- ✅ Certifications with empty URLs now import successfully
- ✅ Certifications with missing URL fields are handled gracefully
- ✅ No breaking changes to existing functionality

## Related Issues
Fixes LinkedIn data import failures when certification URLs are empty or missing.