### PR TITLE
Fix mistake in docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ A free and open-source resume builder that simplifies the process of creating, u
 
 **You can now read them in: Español, Français, Deutsch, Italiano, Português, Português Brasileiro, and Русский.**
 
-**Just use the language switcher at the top of the sidebar on the [Docs Site](https://docsd.rxresume.org) to choose your preferred language. A huge thank you to GitBook for sponsoring these translations!**
+**Just use the language switcher at the top of the sidebar on the [Docs Site](https://docs.rxresume.org) to choose your preferred language. A huge thank you to GitBook for sponsoring these translations!**
 
 ---
 


### PR DESCRIPTION
docsd.rxresume.org -> docs.rxresume.org